### PR TITLE
Update CLI to be more Unix friendly

### DIFF
--- a/cli/antlr-format.ts
+++ b/cli/antlr-format.ts
@@ -150,11 +150,14 @@ if (!options.silent) {
 }
 
 fileList.forEach((grammarPath) => {
-    const [text, changed] = formatGrammar(grammarPath, details, 0, 1e10, options.addOptions);
+    let [text, changed] = formatGrammar(grammarPath, details, 0, 1e10, options.addOptions);
 
     if (changed) {
         if (options.verbose) {
             console.log("  formatted: " + grammarPath);
+        }
+        if (!text.endsWith('\n')) {
+            text += '\n';
         }
         writeFileSync(grammarPath, text);
     } else {


### PR DESCRIPTION
- Ensures files always end with a newline, which is required for UNIX text files.
- Does not overwrite the incoming file if it has not changed it, which is standard UNIX
  practice for files processed in-place.

Closes: #11 
Closes: #9